### PR TITLE
Merge pull request #77 from oktav777/master

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -24,7 +24,7 @@ export class Loader
 	private api: google|undefined;
 
 	constructor(
-		private apiKey: string,
+		private apiKey: string = null,
 		private options: LoaderOptions = {},
 	) {
 		if (typeof window === 'undefined') {
@@ -76,9 +76,12 @@ export class Loader
 	private createUrl(): string
 	{
 		const parameters: Array<string> = [
-			`key=${this.apiKey}`,
 			`callback=${Loader.CALLBACK_NAME}`,
 		];
+
+		if(this.apiKey) {
+			parameters.push(`key=${this.apiKey}`);
+		}
 
 		for (let name in this.options) {
 			if (this.options.hasOwnProperty(name)) {


### PR DESCRIPTION
This commit will make `apiKey` in the constructor optional.

When using Google Maps Platform Premium Plan,
it is possible to authorize using `clientID` only.

See more on [official documentation]

[official documentation]: https://developers.google.com/maps/documentation/javascript/error-messages#key-looks-like-client-id