### PR TITLE
Insert script into DOM using `.appendChild()`

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -69,7 +69,7 @@ export class Loader
 			script.async = true;
 			script.onerror = (e) => reject(e);
 
-			document.head.append(script);
+			document.head.appendChild(script);
 		});
 	}
 


### PR DESCRIPTION
IE11 does not support `Node.append()`.
Using `Node.appendChild()` loader will work on IE11.
Looks like there are no side-effects on changing the method.