### PR TITLE
Replace deprecated google types package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,51 @@
 {
 	"name": "google-maps",
 	"version": "0.0.0-version-placeholder",
-	"lockfileVersion": 1,
+	"lockfileVersion": 2,
 	"requires": true,
+	"packages": {
+		"": {
+			"name": "google-maps",
+			"version": "0.0.0-version-placeholder",
+			"license": "MIT",
+			"dependencies": {
+				"@types/google.maps": "^3.45.2"
+			},
+			"devDependencies": {
+				"@types/node": "^14.0.14",
+				"typescript": "^3.9.5"
+			}
+		},
+		"node_modules/@types/google.maps": {
+			"version": "3.45.2",
+			"resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.45.2.tgz",
+			"integrity": "sha512-3hKhaLt4EcKzssjmpIH8M12tN8WHp/gz7lh+85NdwXGtGSAjtiOEG4st9XdvaZkUHtlNaiAP2PlDbkNnNmD2NQ=="
+		},
+		"node_modules/@types/node": {
+			"version": "14.0.14",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
+			"integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==",
+			"dev": true
+		},
+		"node_modules/typescript": {
+			"version": "3.9.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
+			"integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		}
+	},
 	"dependencies": {
-		"@types/googlemaps": {
-			"version": "3.39.8",
-			"resolved": "https://registry.npmjs.org/@types/googlemaps/-/googlemaps-3.39.8.tgz",
-			"integrity": "sha512-z03u79t1v8QIktoUXypWD06Fzl499/hA162hurA+eCDlWXxFynuU+hMZIaferILF5Gzr4PMX1ShHszT666sUHQ=="
+		"@types/google.maps": {
+			"version": "3.45.2",
+			"resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.45.2.tgz",
+			"integrity": "sha512-3hKhaLt4EcKzssjmpIH8M12tN8WHp/gz7lh+85NdwXGtGSAjtiOEG4st9XdvaZkUHtlNaiAP2PlDbkNnNmD2NQ=="
 		},
 		"@types/node": {
 			"version": "14.0.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,46 +1,8 @@
 {
 	"name": "google-maps",
 	"version": "0.0.0-version-placeholder",
-	"lockfileVersion": 2,
+	"lockfileVersion": 1,
 	"requires": true,
-	"packages": {
-		"": {
-			"name": "google-maps",
-			"version": "0.0.0-version-placeholder",
-			"license": "MIT",
-			"dependencies": {
-				"@types/google.maps": "^3.45.2"
-			},
-			"devDependencies": {
-				"@types/node": "^14.0.14",
-				"typescript": "^3.9.5"
-			}
-		},
-		"node_modules/@types/google.maps": {
-			"version": "3.45.2",
-			"resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.45.2.tgz",
-			"integrity": "sha512-3hKhaLt4EcKzssjmpIH8M12tN8WHp/gz7lh+85NdwXGtGSAjtiOEG4st9XdvaZkUHtlNaiAP2PlDbkNnNmD2NQ=="
-		},
-		"node_modules/@types/node": {
-			"version": "14.0.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
-			"integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==",
-			"dev": true
-		},
-		"node_modules/typescript": {
-			"version": "3.9.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
-			"integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
-			"dev": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
-			}
-		}
-	},
 	"dependencies": {
 		"@types/google.maps": {
 			"version": "3.45.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 	"module": "./lib/esm/index.js",
 	"sideEffects": false,
 	"dependencies": {
-		"@types/googlemaps": "^3.39.1"
+		"@types/google.maps": "^3.45.2"
 	},
 	"devDependencies": {
 		"@types/node": "^14.0.14",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-/// <reference types="googlemaps" />
+/// <reference types="google.maps" />
 
 
 export declare interface google


### PR DESCRIPTION
Hello, guys!

A couple of days ago the package used for types became deprecated and it was replaced by another package with almost the same name.

I hope the solution provided in the PR is fine by you. 😄 

Current package (deprecated): [https://www.npmjs.com/package/@types/googlemaps](url)
New package: [https://www.npmjs.com/package/@types/google.maps](url)